### PR TITLE
Google requires an API key for their Geocode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This project is a work in progress.
 
 ##### Changes
 
+* 2018-05-03, v0.4.1: Google Geocode API update.
+
 * 2017-11-27, v0.4.0: Removing deprecated usage of GeoManager.
 
 * 2017-03-09, v0.3.0: Django 1.10 related fixes.

--- a/simple_geo/__init__.py
+++ b/simple_geo/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import unicode_literals
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/simple_geo/settings.py
+++ b/simple_geo/settings.py
@@ -4,3 +4,4 @@ from django.conf import settings
 SIMPLE_GEO_HIDE_ADMIN = getattr(settings, 'SIMPLE_GEO_HIDE_ADMIN', False)
 SIMPLE_GEO_CITY_MODEL = getattr(settings, 'SIMPLE_GEO_CITY_MODEL', 'simple_geo.City')
 SIMPLE_GEO_POSTALCODE_MODEL = getattr(settings, 'SIMPLE_GEO_POSTALCODE_MODEL', 'simple_geo.PostalCode')
+SIMPLE_GEO_GOOGLE_MAPS_API_KEY = getattr(settings, 'SIMPLE_GEO_GOOGLE_MAPS_API_KEY', False)

--- a/simple_geo/utils.py
+++ b/simple_geo/utils.py
@@ -92,9 +92,10 @@ def geocode(*args, **kwargs):
     query_params = {
         'sensor': 'false',
         'address': kwargs.get('address', '').strip(),
-        'components': ("|".join(components)).format(**component_params)
+        'components': ("|".join(components)).format(**component_params),
+        'key': SIMPLE_GEO_GOOGLE_MAPS_API_KEY
     }
-    url = "http://maps.googleapis.com/maps/api/geocode/json"
+    url = "https://maps.googleapis.com/maps/api/geocode/json"
     response = requests.get(url, params=query_params)
 
     address_data = {}


### PR DESCRIPTION
Google now requires an API key for their Geocode API, so we've added it to the api request.
Users will need to add the SIMPLE_GEO_GOOGLE_MAPS_API_KEY variable to their settings. 
Also have switched the request over to https. 