### PR TITLE
Add support for Django 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This project is a work in progress.
 
 ##### Changes
-* 2023-06-02, v0.5.0: Added support for Django 3.2
+* 2023-06-02, v0.4.4: Added support for Django 3.2
 
 * 2018-11-07, v0.4.3: Django 2.x deprecation fixes.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 This project is a work in progress.
 
 ##### Changes
+* 2023-06-02, v0.5.0: Added support for Django 3.2
 
 * 2018-11-07, v0.4.3: Django 2.x deprecation fixes.
 

--- a/simple_geo/__init__.py
+++ b/simple_geo/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import unicode_literals
-__version__ = '0.4.3'
+__version__ = '0.4.4'

--- a/simple_geo/models.py
+++ b/simple_geo/models.py
@@ -3,7 +3,7 @@ from django.contrib.gis.db.models import PointField
 from django.contrib.gis.geos import Point
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from . import settings as simple_geo_settings

--- a/simple_geo/utils.py
+++ b/simple_geo/utils.py
@@ -5,7 +5,7 @@ import time
 import unicodedata
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+from six import iteritems
 from django.utils.text import slugify
 import requests
 
@@ -88,7 +88,7 @@ def geocode(*args, **kwargs):
     time.sleep(wait)
 
     # get rid of leading/trailing spaces in component values
-    component_params = dict([(k,v.strip()) for k,v in six.iteritems(kwargs)])
+    component_params = dict([(k,v.strip()) for k,v in iteritems(kwargs)])
     query_params = {
         'sensor': 'false',
         'address': kwargs.get('address', '').strip(),


### PR DESCRIPTION
Replace references to django.utils.encoding.python_2_unicode_compatible to new location, six.
Six is also no longer located in django.utils, so change references.